### PR TITLE
Fix styles leaking to light DOM

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,10 @@ export default {
             exclude: 'node_modules/**'
         }),
         bundleText(),
-        postcss({ minimize: true }),
+        postcss({
+            minimize: true,
+            inject: false
+        }),
         nodeResolve({
             // use "jsnext:main" if possible
             // see https://github.com/rollup/rollup/wiki/jsnext:main


### PR DESCRIPTION
The postcss rollup plugin is injecting a copy of styles.css (which is meant to be confined only to the shadow DOM) into the document `<head>`, resulting in styles leaking. Here's an example, where the `p.key` outside of the component picks up styles it shouldn't:

```html
<html>
  <head>
    <script src="https://unpkg.com/@alenaksu/json-viewer"></script>
  </head>
  <body>
      <json-viewer>{"a": [1,2,3]}</json-viewer>
      <p class=key>key</p>
  </body>
</html>
```

This is simply fixed by specifying `inject: false` in the postcss plugin config. 

Thanks for releasing this component, it's very nice :)