### PR TITLE
fix(utils.js): fix JSON parse throwing error on empty content

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ export function isPrimitiveOrNode(obj) {
 
 export function JsonObject(obj) {
     try {
-        if (typeof obj === TYPE_STRING) return JSON.parse(obj);
+        if (typeof obj === TYPE_STRING) return JSON.parse(obj || '{}');
     } catch (ex) {
         console.error(ex);
     }


### PR DESCRIPTION
when the content is empty and we still have data attribute having correct valu
the function throws an error. Fixed it in this commit

Fixes #33 