### PR TITLE
fix: add missing dist folder to export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
         ".": "./dist/json-viewer.js",
         "./src/*": "./src/*.js",
         "./package.json": "./package.json",
-        "./json-viewer.js": "./json-viewer.js",
-        "./JsonViewer.js": "./JsonViewer.js"
+        "./json-viewer.js": "./dist/json-viewer.js",
+        "./JsonViewer.js": "./dist/JsonViewer.js"
     },
     "types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
Great Web Component :)

This PR fixes exports paths in package.json, as current target files do not actually exist. So, this re-enables importing and extending the JsonViewer class again.